### PR TITLE
Update mastodon to 4.1.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # -------------- Build-time variables --------------
-ARG MASTODON_VERSION=4.1.3
+ARG MASTODON_VERSION=4.1.4
 ARG MASTODON_REPOSITORY=tootsuite/mastodon
 
 ARG RUBY_VERSION=3.0


### PR DESCRIPTION
Additional fixes for 4.1.3

https://github.com/mastodon/mastodon/releases/tag/v4.1.4